### PR TITLE
Add a `devapi` environment for using a local API

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -53,6 +53,14 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ]
+            },
+            "devapi": {
+              "fileReplacements": [
+                {
+                  "replace": "src/app/shared/interceptor/mock.interceptor.ts",
+                  "with": "src/app/shared/interceptor/devapi.interceptor.ts"
+                }
+              ]
             }
           }
         },
@@ -64,6 +72,9 @@
           "configurations": {
             "production": {
               "browserTarget": "materialdesign-site:build:production"
+            },
+            "devapi": {
+              "browserTarget": "materialdesign-site:build:devapi"
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6250,6 +6250,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -7266,7 +7275,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
       "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "tslib": "^1.10.0"
       }
@@ -7276,7 +7284,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
       "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
       "dev": true,
-      "peer": true,
       "peerDependencies": {
         "rxjs": "^6.5.3",
         "tslib": "^1.10.0",
@@ -10198,6 +10205,12 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -17894,6 +17907,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -33597,6 +33616,15 @@
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "devOptional": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -34401,6 +34429,8 @@
       "integrity": "sha512-edJIQCIcxD9DhVSyBEdJ38AbLikm515Wl91t5RDGNT88uA6uQdTm4phTWfn9JhzAI8kXNUcfYyAE90lJElpGtA==",
       "dev": true,
       "requires": {
+        "@angular/compiler": "9.0.0",
+        "@angular/core": "9.0.0",
         "app-root-path": "^3.0.0",
         "aria-query": "^3.0.0",
         "axobject-query": "2.0.2",
@@ -34416,17 +34446,17 @@
       },
       "dependencies": {
         "@angular/compiler": {
-          "version": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
           "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
           "dev": true,
-          "peer": true,
           "requires": {}
         },
         "@angular/core": {
-          "version": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
           "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
           "dev": true,
-          "peer": true,
           "requires": {}
         },
         "sprintf-js": {
@@ -36837,6 +36867,12 @@
         "loader-utils": "^2.0.0",
         "schema-utils": "^2.6.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -42763,6 +42799,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/src/app/shared/interceptor/devapi.interceptor.ts
+++ b/src/app/shared/interceptor/devapi.interceptor.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+
+@Injectable()
+export class MockInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    console.log({
+      url: req.url,
+      urlWithParams: req.urlWithParams,
+      body: req.body
+    });
+    const mockReq = req.clone({
+      url: `http://localhost:9080${req.url}`,
+      method: 'GET',
+      params: new HttpParams()
+    });
+    return next.handle(mockReq);
+  }
+}

--- a/src/app/shared/interceptor/mock.interceptor.ts
+++ b/src/app/shared/interceptor/mock.interceptor.ts
@@ -5,13 +5,16 @@ import { Observable } from 'rxjs/Observable';
 @Injectable()
 export class MockInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    let isMock = window.location.href.match(/localhost/) !== null
+    const isMock = window.location.href.match(/localhost/) !== null
       && req.url.match(/^\/api/) != null;
     if (isMock) {
-      console.info(req.urlWithParams);
-      console.info(req.body);
-      let method = req.method.toLowerCase();
-      let mockReq = req.clone({
+      console.log({
+        url: req.url,
+        urlWithParams: req.urlWithParams,
+        body: req.body
+      });
+      const method = req.method.toLowerCase();
+      const mockReq = req.clone({
         url: req.url + `/mock.${method}.json`,
         method: 'GET',
         params: new HttpParams()


### PR DESCRIPTION
Adds a new environment `devapi` which configures the mock interceptor to use a local API instead of mocks.

It can be invoked by `ng server -c devapi`.

This is in support of the devcontainer development system I'm working on.